### PR TITLE
Ga fix

### DIFF
--- a/jekyll-ga.rb
+++ b/jekyll-ga.rb
@@ -60,8 +60,11 @@ module Jekyll
           url = post.url
         end
         if results[url]
-          post.data.merge!("_ga" => results[url].to_i)
+          _ga = results[url].to_i
+        else
+          _ga = 0
         end
+        post.data.merge!("_ga" => _ga)
       }
     end
   end

--- a/jekyll-ga.rb
+++ b/jekyll-ga.rb
@@ -52,8 +52,15 @@ module Jekyll
       results = Hash[response.data.rows]
 
       site.posts.each { |post|
-        if results[post.url + '/']
-          post.data.merge!("_ga" => results[post.url + '/'].to_i)
+        if site.config['permalink'] == 'pretty' || site.config['permalink'].end_with?('/')
+          url = post.url + 'index.html'
+        elsif !site.confi['permalink'].end_with?('/')
+          url = post.url + 'index'
+        else
+          url = post.url
+        end
+        if results[url]
+          post.data.merge!("_ga" => results[url].to_i)
         end
       }
     end


### PR DESCRIPTION
In case that ga results don't have a entry for post's url, set `post._ga` to 0. So that sorting plugins (such as jekyll-sort) can sort on `_ga` in either case.
